### PR TITLE
build 1.1.1 at commit 8a62d0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: ctypesgen-pypdfium2-team

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-aggregate_branch: ctypesgen-pypdfium2-team

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   entry_points:
     - ctypesgen = ctypesgen.main:main
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: {{ name|lower }}-pypdfium2-team
-  version: 1.1.1+4_g8a62d02 # this will be later replaced by {{ GIT_DESCRIBE_TAG }}+{{ GIT_BUILD_STR }}
+  version: 1.1.1+4_g8a62d02 # this will be later replaced by {{ GGIITT_DESCRIBE_TAG }}+{{ GGIITT_BUILD_STR }}
 
 source:
   git_url: https://github.com/pypdfium2-team/{{ name }}.git

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: {{ name|lower }}-pypdfium2-team
-  version: 1.1.1+4_g8a62d02 # this will be later replaced by {{ GGIITT_DESCRIBE_TAG }}+{{ GGIITT_BUILD_STR }}
+  version: 1.1.1+4_g8a62d02 # this will be later by proper conda jinja vars
 
 source:
   git_url: https://github.com/pypdfium2-team/{{ name }}.git

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,8 @@ build:
   number: 0
 
 requirements:
+  build:
+    - git  # [not win]
   host:
     - python
     - setuptools >=44

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,8 @@
 {% set name = "ctypesgen" %}
-{% set version = "1.1.1a" %}
 
 package:
   name: {{ name|lower }}-pypdfium2-team
-  version: {{ version }}
+  version: {{ GIT_DESCRIBE_TAG }}+{{ GIT_BUILD_STR }}
 
 source:
   git_url: https://github.com/pypdfium2-team/{{ name }}.git

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,31 +1,31 @@
 {% set name = "ctypesgen" %}
-{% set version = "1.1.2.dev4+g8a62d02" %}
+{% set version = "8a62d0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: file:///Users/jolivieri/repos/upstream/ctypesgen-pypdfium2-team/dist/ctypesgen-1.1.2.dev4+g8a62d02.tar.gz
-  sha256: d23910fd783b8eb89d30cbb51b9c1bbedcc4143a50617c69959da4951cac94f9
+  git_url: https://github.com/pypdfium2-team/{{ name }}.git
+  git_rev: {{ version }}
 
 build:
   entry_points:
     - ctypesgen = ctypesgen.main:main
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - setuptools >=44
     - wheel
     - setuptools-scm >=3.4.3
     - toml
     - pip
   run:
-    - python >=3.7
+    - python
 
 test:
   imports:
@@ -37,10 +37,16 @@ test:
     - pip
 
 about:
-  home: https://github.com/ctypesgen/ctypesgen
+  home: https://github.com/pypdfium2-team/ctypesgen
   summary: Python wrapper generator for ctypes
+  description: |
+    ctypesgen is a pure-python ctypes wrapper generator. It parses C header files and creates a wrapper for
+    libraries based on what it finds.
   license: BSD-2-Clause
   license_file: LICENSE
+  license_family: BSD
+  doc_url: https://github.com/pypdfium2-team/ctypesgen
+  dev_url: https://github.com/pypdfium2-team/ctypesgen
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: {{ name|lower }}-pypdfium2-team
-  version: {{ GIT_DESCRIBE_TAG }}+{{ GIT_BUILD_STR }}
+  version: 1.1.1+4_g8a62d02 # this will be later replaced by {{ GIT_DESCRIBE_TAG }}+{{ GIT_BUILD_STR }}
 
 source:
   git_url: https://github.com/pypdfium2-team/{{ name }}.git

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,5 +50,3 @@ about:
 extra:
   recipe-maintainers:
     - boldorider4
-  skip-lints:
-    - host_section_needs_exact_pinnings

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ctypesgen" %}
-{% set version = "8a62d0" %}
+{% set version = "1.1.1a" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   git_url: https://github.com/pypdfium2-team/{{ name }}.git
-  git_rev: {{ version }}
+  git_rev: 8a62d0
 
 build:
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,8 @@ requirements:
     - pip
   run:
     - python
+  run_constrained:
+    - ctypesgen <=0.0.0dev0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   git_url: https://github.com/pypdfium2-team/{{ name }}.git
-  git_rev: 8a62d0
+  git_rev: 8a62d02a6fd350df6d22e179bcd164df0da770d4
 
 build:
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "1.1.1a" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name|lower }}-pypdfium2-team
   version: {{ version }}
 
 source:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,3 +50,5 @@ about:
 extra:
   recipe-maintainers:
     - boldorider4
+  skip-lints:
+    - host_section_needs_exact_pinnings


### PR DESCRIPTION
* [x] checked upstream repo [requirements](https://github.com/pypdfium2-team/ctypesgen/blob/1.1.1/pyproject.toml)
* [x] checked [license](https://github.com/pypdfium2-team/ctypesgen/blob/1.1.1/LICENSE)
* [x] created from scratch with [grayskull](https://github.com/conda/grayskull)

notes:

- upstream is a [fork](https://github.com/pypdfium2-team/ctypesgen) of [ctypesgen](https://github.com/ctypesgen/ctypesgen)
- last tag (1.1.1) dates back to Oct 19 2022, but latest master state was used on Jul 4 2023 when dependent `pypdfium2` was released, hence this feedstock PR.
- version has been manually formulated since [conda-build](https://github.com/conda/conda-build/blob/3.24.0/conda_build/source.py#L330-L332) expects `git` to be installed prior to checking the `build` requirements, thus making `{{ GIT_DESCRIBE_TAG }}+{{ GIT_BUILD_STR }}` unintelligible.