### PR TITLE
update to 1.1.1+17

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # ctypesgen-pypdfium2-team-feedstock
+
+## Home
+https://github.com/pypdfium2-team/ctypesgen
+
+ctypesgen is a pure-python ctypes wrapper generator. This feedstock builds a particular fork owned by _pypdfium-team_.
+
+## License
+BSD-2 simplified license
+
+## Feedstock License
+BSD-3
+
+ctypesgen parses C header files and creates a wrapper for libraries based on what it finds.
+
+Preprocessor macros are handled in a manner consistent with typical C code. Preprocessor macro functions are translated into Python functions that are then made available to the user of the newly-generated Python wrapper library.
+
+It can also output JSON, which can be used with Mork, which generates bindings for Lua, using the alien module (which binds libffi to Lua).
+
+
+## Docs
+https://github.com/pypdfium2-team/ctypesgen
+
+## Dev
+https://github.com/pypdfium2-team/ctypesgen

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   entry_points:
-    - ctypesgen = ctypesgen.main:main
+    - ctypesgen = ctypesgen.__main__:main
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,11 +2,11 @@
 
 package:
   name: {{ name|lower }}-pypdfium2-team
-  version: 1.1.1+4_g8a62d02 # this will be later by proper conda jinja vars
+  version: 1.1.1+17_g10b2b4 # this will be later by proper conda jinja vars
 
 source:
   git_url: https://github.com/pypdfium2-team/{{ name }}.git
-  git_rev: 8a62d02a6fd350df6d22e179bcd164df0da770d4
+  git_rev: 10b2b4be34c671613b3c4483bc068fa34e0a4d9e
 
 build:
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,9 +19,9 @@ requirements:
     - git  # [not win]
   host:
     - python
-    - setuptools >=44
+    - setuptools 68.0.0
     - wheel
-    - setuptools-scm >=3.4.3
+    - setuptools-scm 7.1.0
     - toml
     - pip
   run:


### PR DESCRIPTION
This commit belongs to the `pypdfium2` branch of the [upstream](https://github.com/pypdfium2-team/ctypesgen/tree/pypdfium2) project.

Before Jul 4th (the date of release of `pypdfium2 4.18.0`, a dependent of `ctypesgen`) the last commit of the ctypesgen upstream repo that was used was `10b2b4be34c671613b3c4483bc068fa34e0a4d9e`.

The maintainer of `pypdfium` did not specify a specific release version or a package name for the dependency on `ctypesgen` but rather specified the git repo URL and branch used.